### PR TITLE
Fixed issue in write_provide_ports

### DIFF
--- a/apx/node_data.py
+++ b/apx/node_data.py
@@ -141,6 +141,8 @@ class NodeData():
          port_id = port_id.id
       if not isinstance(port_id, int):
          raise ValueError('port_id must be integer')
+      if not value in range(0x7fff * 2 + 1):
+         raise ValueError("the provided value does not conform to range: 0 <= value <= 0x7fff * 2 + 1")
       port_map = self.outPortDataMap[port_id]
       assert(port_id == port_map.port.id)
       return self._packProvidePort(port_id, port_map.data_offset, port_map.data_len, value)


### PR DESCRIPTION
Fixed an issue with  **write_provide_ports** method.

**Problem description:**
While updating provide ports value, if the user sends some value that is out of range (0 <= value <= 0x7fff * 2 + 1), the update fails. After this, even if the correct value is sent for updating, the server control gets stuck and no further updates are allowed.

**Solution:**
Added a condition that throws a "ValueError" when the user sends some incorrect value (out of range value), so that write_provide_ports method works as expected.